### PR TITLE
Update repository to GoCD deb site and use their key

### DIFF
--- a/manifests/repository.pp
+++ b/manifests/repository.pp
@@ -18,7 +18,7 @@ class go::repository {
     }
     debian: {
       exec{'add_publickey_go':
-        command     => "wget --quiet -O - 'https://bintray.com/user/downloadSubjectPublicKey?username=gocd' | sudo apt-key add -",
+        command     => "wget --quiet -O - 'https://download.go.cd/GOCD-GPG-KEY.asc' | sudo apt-key add -",
         path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
         refreshonly => true,
         subscribe   => File['/etc/apt/sources.list.d/gocd.list'],
@@ -28,7 +28,7 @@ class go::repository {
         owner   => 'root',
         group   => 'root',
         mode    => '0644',
-        content => 'deb http://dl.bintray.com/gocd/gocd-deb/ /',
+        content => 'deb https://download.go.cd /',
       }
       exec {'go_run_apt_get_update':
         command     => 'apt-get update',


### PR DESCRIPTION
I tried this module last week but got errors when installing the package from the managed repo. This merge updates the repository.pp to use the key and apt repo from the go cd install guide.

https://docs.go.cd/16.3.0/installation/install/agent/linux.html

