### PR TITLE
Adding autoregister hostname

### DIFF
--- a/manifests/agent/instance.pp
+++ b/manifests/agent/instance.pp
@@ -45,6 +45,10 @@
 #   Environment that go agent will belong to. Leave unset for no environment
 #   Valid values: string - environment name
 #
+# [*autoregister_hostname*]
+#   The name that you want to display on the server
+#   Valid values: string - agent name
+#
 # [*manage_user*]
 #   If the instance user and home directory should be managed
 #   Valid values: boolean
@@ -91,7 +95,7 @@ define go::agent::instance (
   $autoregister_key       = undef,
   $autoregister_resources = undef,
   $autoregister_env       = undef,
-  $autoregister_hostname  = $name,
+  $autoregister_hostname  = undef,
   $manage_user            = true,
   $service_ensure         = 'running',
   $service_enable         = true,

--- a/manifests/agent/instance.pp
+++ b/manifests/agent/instance.pp
@@ -91,6 +91,7 @@ define go::agent::instance (
   $autoregister_key       = undef,
   $autoregister_resources = undef,
   $autoregister_env       = undef,
+  $autoregister_hostname  = $name,
   $manage_user            = true,
   $service_ensure         = 'running',
   $service_enable         = true,

--- a/templates/autoregister.properties.erb
+++ b/templates/autoregister.properties.erb
@@ -1,6 +1,7 @@
 # MANAGED BY PUPPET
 agent.auto.register.key=<%= @autoregister_key %>
 agent.auto.register.resources=<%= @autoregister_resources.join(',') %>
+agent.auto.register.hostname=<%= @autoregister_hostname %>
 <%- if @autoregister_env != nil -%>
 agent.auto.register.environments=<%= @autoregister_env -%>
 <%- end -%>

--- a/templates/autoregister.properties.erb
+++ b/templates/autoregister.properties.erb
@@ -1,7 +1,9 @@
 # MANAGED BY PUPPET
 agent.auto.register.key=<%= @autoregister_key %>
 agent.auto.register.resources=<%= @autoregister_resources.join(',') %>
+<%- if @autoregister_hostname != nil -%>
 agent.auto.register.hostname=<%= @autoregister_hostname %>
+<%- end -%>
 <%- if @autoregister_env != nil -%>
 agent.auto.register.environments=<%= @autoregister_env -%>
 <%- end -%>


### PR DESCRIPTION
Creating multiple agents on the one server will cause all agents to use the same Agent Name. Changed code to use the $name passed to the define type as part of the auto registration.